### PR TITLE
Instead of creating fields on the type, we should create properties

### DIFF
--- a/DynamicSelectExtensions/IQueryableExtensions.cs
+++ b/DynamicSelectExtensions/IQueryableExtensions.cs
@@ -9,10 +9,8 @@ using System.Linq.Expressions;
 
 namespace thiscode.Tools.DynamicSelectExtensions
 {
-
     public static class IQueryableExtensions
     {
-
         /// <summary>
         /// Use this to select only specific fields, instead fetching the whole entity.
         /// </summary>
@@ -23,7 +21,7 @@ namespace thiscode.Tools.DynamicSelectExtensions
         ///         "Property1",
         ///         "Property2",
         ///     });
-        ///     
+        ///
         /// dynamic FirstObj = query.FirstOrDefault();
         /// Console.WriteLine(FirstObj.Property1); //Name of the member will validated in runtime!
         /// </code></example>
@@ -58,7 +56,8 @@ namespace thiscode.Tools.DynamicSelectExtensions
             var dynamicType = DynamicTypeBuilder.GetDynamicType(sourceProperties.Values.ToDictionary(f => f.Name, f => f.PropertyType), typeof(object), Type.EmptyTypes);
 
             //Create the Binding Expressions
-            var bindings = dynamicType.GetFields().Select(p => Expression.Bind(p, Expression.Property(sourceItem, sourceProperties[p.Name]))).OfType<MemberBinding>().ToList();
+            var bindings = dynamicType.GetProperties().Where(p => p.CanWrite)
+                .Select(p => Expression.Bind(p, Expression.Property(sourceItem, sourceProperties[p.Name]))).OfType<MemberBinding>().ToList();
 
             //Create the Projection
             var selector = Expression.Lambda<Func<T, dynamic>>(Expression.MemberInit(Expression.New(dynamicType.GetConstructor(Type.EmptyTypes)), bindings), sourceItem);
@@ -83,7 +82,7 @@ namespace thiscode.Tools.DynamicSelectExtensions
         /// <param name="source">Source IQueryable</param>
         /// <param name="includeExpessions">Lamda Expressions, defining what entities to include</param>
         /// <returns></returns>
-        public static IEnumerable<T> SelectIncluding<T>(this IQueryable<T> source, IEnumerable<Expression<Func<T,object>>> includeExpessions)
+        public static IEnumerable<T> SelectIncluding<T>(this IQueryable<T> source, IEnumerable<Expression<Func<T, object>>> includeExpessions)
         {
             if (source == null) throw new ArgumentNullException("Source Object is NULL");
 
@@ -115,15 +114,15 @@ namespace thiscode.Tools.DynamicSelectExtensions
             //
             //    });
 
-            //Now we fire up the query (AsEnumerable) and then unwrap the SupplierItem out 
-            //of the anonymous type (Select). 
-            
+            //Now we fire up the query (AsEnumerable) and then unwrap the SupplierItem out
+            //of the anonymous type (Select).
+
             //return query.AsEnumerable().Select(mainEntity => mainEntity.mainEntity);
 
-            //Because the ObjectContext have collected all the related entities, it have also linked each other correctly over 
+            //Because the ObjectContext have collected all the related entities, it have also linked each other correctly over
             //navigation-properties and reference-properties. Please read this Tip, too:
             //http://blogs.msdn.com/b/alexj/archive/2009/10/13/tip-37-how-to-do-a-conditional-include.aspx
-            
+
             //We build here firstly the Expression needed by the Select-Method dynamicly.
             //Beyond this we build even the class dynamicly. The class includes only
             //the Properties we want to project. The difference is, that the class is
@@ -166,7 +165,7 @@ namespace thiscode.Tools.DynamicSelectExtensions
                 typeDetected = includeExpession.Body.Type;
                 //Save into List
                 dynamicFields.Add("f" + dynamicFieldsCounter, new Tuple<Expression, Type>(
-                    paramRewriter.ReplaceParameter(includeExpession.Body,includeExpession.Parameters[0]),
+                    paramRewriter.ReplaceParameter(includeExpession.Body, includeExpession.Parameters[0]),
                     typeDetected
                     ));
                 //Count
@@ -214,8 +213,7 @@ namespace thiscode.Tools.DynamicSelectExtensions
                 else return node;
             }
         }
-
     }
-
 }
+
                               


### PR DESCRIPTION
Instead of creating fields on the type, we should create properties with getters and setters

Through testing I found that while Json.Net serialized fields just fine, ServiceStack.Text doesn't and instead returned an empty object

Performance has not been affected by this change, tested on generating lists of 100,000

If curious, spitting out a list of new strongly typed objects it takes 7ms.  Creating a list of a strong anonymous type takes 15ms.  Creating a list using this code takes 16ms - which is mighty impressive
